### PR TITLE
Pin setuptools<81 in doc extra to fix ReadTheDocs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning][].
   key, which crashes `spatialdata`'s `TableModel.parse` validation
   (`AttributeError: 'NoneType' object has no attribute 'lower'`) and broke
   the `PRE-RELEASE DEPENDENCIES` CI job.
+- Pinned `setuptools<81` in the `doc` extra: `setuptools>=81` removed
+  `pkg_resources`, which `xarray_schema` (a `spatialdata` dependency) still
+  imports at module load, crashing `import troutpy` and, with it, the
+  ReadTheDocs build (`sphinx.errors.ExtensionError: ... no module named
+  troutpy.pl`).
 
 ## [0.1.1]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,9 @@ optional-dependencies.doc = [
   "myst-nb>=1.1",
   "pandas",
   # Until pybtex >0.23.0 releases: https://bitbucket.org/pybtex-devs/pybtex/issues/169/
-  "setuptools",
+  # setuptools<81: setuptools>=81 dropped pkg_resources, which xarray_schema
+  # (a spatialdata dep) still imports at module load, breaking `import troutpy`.
+  "setuptools<81",
   "sphinx>=4",
   "sphinx-autodoc-typehints",
   "sphinx-book-theme>=1",


### PR DESCRIPTION
setuptools>=81 removed pkg_resources, which xarray_schema (a spatialdata dependency) still imports at module load. This crashes `import troutpy` on RTD, which surfaces to Sphinx's autosummary as a generic "no module named troutpy.pl" ExtensionError that aborts the whole build.